### PR TITLE
Use INVENTORY in preinit as well

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ help: ## This help message
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^(\s|[a-zA-Z_0-9-])+:.*?##/ { printf "  \033[36m%-35s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 preinit: ## Setup ansible environemnt - configure ansible.cfg and download collections
-	ansible-playbook init_env/pre_init_env.yml $(EXTRA_PLAYBOOK_OPTS)
+	ansible-playbook -i $(INVENTORY) init_env/pre_init_env.yml $(EXTRA_PLAYBOOK_OPTS)
 
 fix_aws_dns: ## Update public DNS for AWS - needed when a VM cold starts
 	ansible-playbook init_env/aws/fix_aws_dns.yml $(EXTRA_PLAYBOOK_OPTS)


### PR DESCRIPTION
Otherwise we get ansible_user undefined errors no matter what is in the
inventory file, which is where we document setting ansible_user
