### PR TITLE
Add ami copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,13 +226,6 @@ The variables to include builds for the extra components are all Ansible boolean
 
 ###  4.4. <a name='AWS-SpecificConfiguration'></a>AWS-Specific Configuration
 
-*Note:* The provisioning code stores the SSH keypair for instance logins in an S3 bucket which is named based on the
-pattern. This means that the same user can install the same pattern in exactly one AWS region at present. Further,
-the S3 bucket takes some time to delete, so if you immediately delete a pattern from one region and try to install it
-in another region, the creation of the S3 bucket may fail because the previous S3 bucket may not have actually been
-deleted yet. As a workaround, you can change the `ec2_name_prefix` which will create a different bucket for the new
-pattern, or else wait until the bucket name has been fully deleted by AWS.
-
 | Name                      | Description                          | Required | Default            | Notes  |
 | ------------------------- | ------------------------------------ | -------- | ------------------ | ------ |
 | aws_account_nbr_vault     | AWS Account Number                   | false    |                    | The AWS Account Number is used by ImageBuilder to share the resulting image to as an AMI |

--- a/README.md
+++ b/README.md
@@ -226,6 +226,13 @@ The variables to include builds for the extra components are all Ansible boolean
 
 ###  4.4. <a name='AWS-SpecificConfiguration'></a>AWS-Specific Configuration
 
+*Note:* The provisioning code stores the SSH keypair for instance logins in an S3 bucket which is named based on the
+pattern. This means that the same user can install the same pattern in exactly one AWS region at present. Further,
+the S3 bucket takes some time to delete, so if you immediately delete a pattern from one region and try to install it
+in another region, the creation of the S3 bucket may fail because the previous S3 bucket may not have actually been
+deleted yet. As a workaround, you can change the `ec2_name_prefix` which will create a different bucket for the new
+pattern, or else wait until the bucket name has been fully deleted by AWS.
+
 | Name                      | Description                          | Required | Default            | Notes  |
 | ------------------------- | ------------------------------------ | -------- | ------------------ | ------ |
 | aws_account_nbr_vault     | AWS Account Number                   | false    |                    | The AWS Account Number is used by ImageBuilder to share the resulting image to as an AMI |
@@ -248,6 +255,7 @@ The variables to include builds for the extra components are all Ansible boolean
 | activation_key_vault      | Activation Key Name to embed in image  | true  |                    | This is an activation key for the Red Hat CDN. It is expected to be able to enable both the base RHEL repos and the AAP repos. |
 | skip_imagebuilder_build   | Flag to skip imagebuilder build (also set `imagebuilder_ami` if true) |  false | false     | |
 | imagebuilder_ami   | AMI to use for VM creation in AWS  | false             | | It is very possible to re-use another imagebuilder build from a previous installation of the pattern framework, and saves ~15 minutes on a new pattern install to re-use such an image. |
+| ami_source_region   | Source Region to copy AMI from if not present in target region  | false             | us-east-1 | Imagebuilder puts its images in us-east-1 by default. If you specify a non-imagebuilder ami and it "starts out" in a different region, you can specify that here. |
 
 ##  5. <a name='WhattheFrameworkDoesStep-by-Step'></a>What the Framework Does, Step-by-Step
 

--- a/init_env/aws/main.yml
+++ b/init_env/aws/main.yml
@@ -79,7 +79,7 @@
       ansible.builtin.include_role:
         name: roles/manage_ec2_instances
       vars:
-        imagebuilder_ami: "{{ copied_ami | default(imagebuilder_ami) }}"
+        ami_id: "{{ copied_ami | default(imagebuilder_ami) }}"
 
 - name: Post-provisioning tasks
   hosts: aws_nodes

--- a/init_env/aws/main.yml
+++ b/init_env/aws/main.yml
@@ -26,9 +26,36 @@
       ansible.builtin.include_role:
         name: roles/manage_ec2_infra
 
-    - name: Build VMs and manage DNS entries
-      ansible.builtin.include_role:
-        name: roles/manage_ec2_instances
+    - name: Include vars from previous runs
+      ansible.builtin.include_vars:
+        file: '{{ pattern_state_rootdir }}/{{ ec2_name_prefix }}/aws_state_vars.yml'
+      ignore_errors: true
+      when: save_aws_vars
+
+    - name: Copy AMI image if needed
+      block:
+        - name: Check for AMI in ec2 region
+          amazon.aws.ec2_ami:
+            image_id: "{{ imagebuilder_ami }}"
+            region: "{{ ec2_region }}"
+          register: ami_query
+          failed_when:
+            - "'InvalidAMIID.NotFound' in '{{ ami_query.msg }}'"
+      rescue:
+        - name: Copy image to desired region
+          community.aws.ec2_ami_copy:
+            source_region: "{{ ami_source_region }}"
+            region: "{{ ec2_region }}"
+            source_image_id: "{{ imagebuilder_ami }}"
+            wait: true
+          register: ami_copy
+
+        - name: Set AMI ID now that we have a new one
+          ansible.builtin.set_fact:
+            copied_ami: "{{ ami_copy.image_id }}"
+      when:
+        - copied_ami is not defined
+        - ami_source_region != ec2_region
 
     - name: Save variables for later if desired
       ansible.builtin.copy:
@@ -41,9 +68,18 @@
 
            pattern_dns_zone: '{{ pattern_dns_zone }}'
 
+           {% if copied_ami is defined %}
+           copied_ami: '{{ copied_ami }}'
+           {% endif %}
            imagebuilder_ami: '{{ imagebuilder_ami }}'
         dest: '{{ pattern_state_rootdir }}/{{ ec2_name_prefix }}/aws_state_vars.yml'
       when: save_aws_vars
+
+    - name: Build VMs and manage DNS entries
+      ansible.builtin.include_role:
+        name: roles/manage_ec2_instances
+      vars:
+        imagebuilder_ami: "{{ copied_ami | default(imagebuilder_ami) }}"
 
 - name: Post-provisioning tasks
   hosts: aws_nodes

--- a/init_env/aws/main.yml
+++ b/init_env/aws/main.yml
@@ -39,8 +39,7 @@
             image_id: "{{ imagebuilder_ami }}"
             region: "{{ ec2_region }}"
           register: ami_query
-          failed_when:
-            - "'InvalidAMIID.NotFound' in '{{ ami_query.msg }}'"
+          failed_when: ami_query.msg is search('InvalidAMIID.NotFound')
       rescue:
         - name: Copy image to desired region
           community.aws.ec2_ami_copy:

--- a/init_env/aws/roles/aws_check_setup/tasks/main.yml
+++ b/init_env/aws/roles/aws_check_setup/tasks/main.yml
@@ -28,16 +28,8 @@
       - "admin_password cannot be set to ansible"
       - "please set a unique password for your pattern"
 
-- name: grab boto version
-  command: "{{ansible_python['executable']}} -c 'import boto3; print(boto3.__version__)'"
-  register: py_cmd
-  changed_when: false
-
-- name: make sure we are running correct boto version
-  assert:
-    that:
-      - py_cmd.stdout is version('1.7', operator='ge')
-    msg: "boto3 >= 1.7 is required."
+# Previously we had a boto3 version check on the controller. This caused problems with homebrew installed, so
+# it was removed. (The version was quite old that we were checking for)
 
 - name: check route53 information
   when: dns_type == "aws"

--- a/init_env/aws/roles/manage_ec2_infra/tasks/resources/aws.yml
+++ b/init_env/aws/roles/manage_ec2_infra/tasks/resources/aws.yml
@@ -6,7 +6,7 @@
     region: "{{ ec2_region }}"
     tags:
       Pattern: "{{ ec2_name_prefix }}"
-  retries: 4
+  retries: 100
   delay: 15
   register: s3_result
   until: s3_result.failed == false

--- a/init_env/aws/roles/manage_ec2_infra/tasks/resources/aws.yml
+++ b/init_env/aws/roles/manage_ec2_infra/tasks/resources/aws.yml
@@ -1,19 +1,19 @@
 ---
 - name: s3 bucket for persistent storage of ec2 key exists
   amazon.aws.s3_bucket:
-    name: "{{ ec2_name_prefix|lower }}.{{ pattern_dns_zone|lower }}.private"
+    name: "{{ ec2_name_prefix|lower }}.{{ pattern_dns_zone|lower }}.{{ ec2_region }}.private"
     state: present
     region: "{{ ec2_region }}"
     tags:
       Pattern: "{{ ec2_name_prefix }}"
-  retries: 300
+  retries: 4
   delay: 15
   register: s3_result
   until: s3_result.failed == false
 
 - name: Store SSH Key Pair
   amazon.aws.aws_s3:
-    bucket: "{{ ec2_name_prefix|lower }}.{{ pattern_dns_zone }}.private"
+    bucket: "{{ ec2_name_prefix|lower }}.{{ pattern_dns_zone|lower }}.{{ ec2_region }}.private"
     mode: put
     object: "{{ec2_name_prefix}}-private.pem"
     src: "{{ pattern_state_rootdir }}/{{ ec2_name_prefix|lower }}/{{ ec2_name_prefix|lower }}-private.pem"
@@ -23,7 +23,7 @@
 
 - name: Save Private key from S3 Bucket when not generating it
   amazon.aws.aws_s3:
-    bucket: "{{ ec2_name_prefix|lower }}.{{ pattern_dns_zone }}.private"
+    bucket: "{{ ec2_name_prefix|lower }}.{{ pattern_dns_zone|lower }}.{{ ec2_region }}.private"
     mode: get
     object: "{{ ec2_name_prefix }}-private.pem"
     dest: "{{ pattern_state_rootdir }}/{{ ec2_name_prefix|lower }}/{{ ec2_name_prefix|lower }}-private.pem"

--- a/init_env/aws/roles/manage_ec2_infra/tasks/resources/aws.yml
+++ b/init_env/aws/roles/manage_ec2_infra/tasks/resources/aws.yml
@@ -6,7 +6,7 @@
     region: "{{ ec2_region }}"
     tags:
       Pattern: "{{ ec2_name_prefix }}"
-  retries: 100
+  retries: 300
   delay: 15
   register: s3_result
   until: s3_result.failed == false

--- a/init_env/aws/roles/manage_ec2_infra/tasks/resources/resources.yml
+++ b/init_env/aws/roles/manage_ec2_infra/tasks/resources/resources.yml
@@ -14,14 +14,14 @@
   until: create_vpc is not failed
   retries: 5
 
-- name: create file for all AWS security group rules
+- name: Create file for all AWS security group rules
   template:
     src: vpc_rules.j2
     dest: "{{pattern_state_rootdir}}/{{ec2_name_prefix}}/aws_rules.yml"
   delegate_to: localhost
   run_once: true
 
-- include_vars:
+- ansible.builtin.include_vars:
     file: "{{pattern_state_rootdir}}/{{ec2_name_prefix}}/aws_rules.yml"
 
 - name: Create EC2 security group for VPC named {{ ec2_name_prefix }}-vpc
@@ -60,7 +60,7 @@
   until: create_subnet is not failed
   retries: 15
 
-- name: vpc internet gateway is present for {{ create_vpc.vpc.id }}
+- name: Vpc internet gateway is present for {{ create_vpc.vpc.id }}
   amazon.aws.ec2_vpc_igw:
     region: "{{ ec2_region }}"
     vpc_id: "{{ create_vpc.vpc.id }}"
@@ -73,7 +73,7 @@
   until: igw is not failed
   retries: 15
 
-- name: vpc public subnet route table is present for {{ create_vpc.vpc.id }}
+- name: Vpc public subnet route table is present for {{ create_vpc.vpc.id }}
   amazon.aws.ec2_vpc_route_table:
     region: "{{ ec2_region }}"
     vpc_id: "{{ create_vpc.vpc.id }}"
@@ -103,23 +103,27 @@
     region: "{{ ec2_region }}"
   register: create_key
 
-- name: save private key
-  copy:
+#- name: Debug create key
+#  ansible.builtin.debug:
+#    var: create_key
+
+- name: Save private key
+  ansible.builtin.copy:
     content: "{{ create_key.key.private_key }}"
     dest: "{{ pattern_state_rootdir }}/{{ ec2_name_prefix }}/{{ ec2_name_prefix }}-private.pem"
     mode: '0400'
   when: create_key.changed
 
-- name: use {{ dns_type }} storage for key
-  include_tasks: "{{ dns_type }}.yml"
+- name: Use {{ dns_type }} storage for key
+  ansible.builtin.include_tasks: "{{ dns_type }}.yml"
 
 - name: Ensure key file has proper permissions
-  file:
+  ansible.builtin.file:
     dest: "{{ pattern_state_rootdir }}/{{ ec2_name_prefix }}/{{ ec2_name_prefix }}-private.pem"
     mode: 0600
 
-- name: debugging all variables for ec2 instance creation VPC-1
-  debug:
+- name: Debugging all variables for ec2 instance creation VPC-1
+  ansible.builtin.debug:
     msg:
       - "ec2_name_prefix: {{ ec2_name_prefix }}"
       - "ec2_vpc_id: {{ ec2_vpc_id }}"

--- a/init_env/aws/roles/manage_ec2_infra/tasks/teardown.yml
+++ b/init_env/aws/roles/manage_ec2_infra/tasks/teardown.yml
@@ -173,7 +173,7 @@
 
 - name: delete s3 bucket for persistent storage of ec2 key
   amazon.aws.s3_bucket:
-    name: "{{ ec2_name_prefix|lower }}.{{ pattern_dns_zone|lower }}.private"
+    name: "{{ ec2_name_prefix|lower }}.{{ pattern_dns_zone|lower }}.{{ ec2_region }}.private"
     state: absent
     region: "{{ ec2_region }}"
     force: true

--- a/init_env/aws/roles/manage_ec2_instances/tasks/ensure_ec2_instance.yml
+++ b/init_env/aws/roles/manage_ec2_instances/tasks/ensure_ec2_instance.yml
@@ -9,7 +9,7 @@
         key_name: "{{ ec2_name_prefix }}-key"
         security_group: "{{ inst.security_group_id | default(ec2_security_group) }}"
         instance_type: "{{ inst.instance_type | default('m4.large') }}"
-        image_id: "{{ inst.image_id | default(imagebuilder_ami) }}"
+        image_id: "{{ inst.image_id | default(ami_id) }}"
         region: "{{ inst.region_id | default(ec2_region) }}"
         state: running
         filters:

--- a/init_env/aws/teardown.yml
+++ b/init_env/aws/teardown.yml
@@ -17,7 +17,7 @@
       rescue:
         - name: Error with setup
           fail:
-            msg: The provisioner has failed during initial check_setup, please scroll up to see exact error.  Open an issue on https://github.com/ansible/workshops/issues
+            msg: The provisioner has failed during initial check_setup, please scroll up to see exact error.  Open an issue on https://github.com/validatedpatterns/agof/issues
 
 - name: "Get info on the elements built"
   hosts: localhost

--- a/init_env/aws/vars/aws_vars.yml
+++ b/init_env/aws/vars/aws_vars.yml
@@ -6,6 +6,8 @@ aws_remote_tmp: '/tmp/.ansible'
 pattern_domain: "{{ ec2_name_prefix }}.{{ pattern_dns_zone }}"
 pattern_state_rootdir: "{{ '~' | expanduser }}"
 
+ami_source_region: 'us-east-1'
+
 build_aap_from_image: true
 
 imagebuilder_include_filesystem: false

--- a/requirements.yml
+++ b/requirements.yml
@@ -7,6 +7,7 @@ collections:
 - ansible.netcommon
 - ansible.posix
 - ansible.utils
+- community.aws
 - community.general
 - containers.podman
 - redhat_cop.controller_configuration


### PR DESCRIPTION
Enable the use of AGOF for non-us-east-1 AWS regions using AMI copy.

AWS AMI's have unique AMI IDs in each region they exist, so if an ami is copied it gets a new AMI id.

This code checks for the existence if the imagebuilder_ami in the region that is requested, and if it is not found, copies it from the ami_source_region (by default us-east-1). This covers the default case.

In this process, it also became apparent that bucket names take a long time to be deleted. Added ec2_region to the bucket name to prevent long delays in spinning up the same pattern in different regions.