### PR TITLE
Skip imagebuilder when previous image found in statefile

### DIFF
--- a/init_env/buildimage/main.yml
+++ b/init_env/buildimage/main.yml
@@ -10,6 +10,23 @@
     - ~/agof_vault.yml
 
   tasks:
+    - name: Check for previous imagebuilder build record
+      block:
+        - name: Read previous state_vars file if present
+          ansible.builtin.include_vars:
+            file: "{{ '~' | expanduser }}/{{ ec2_name_prefix }}/aws_state_vars.yml"
+            name: state_vars
+          failed_when: false
+
+        - name: Disable imagebuild when previously built AMI found
+          ansible.builtin.set_fact:
+            skip_imagebuilder_build: true
+          when: state_vars.imagebuilder_ami is defined
+      rescue:
+        - name: Recover
+          ansible.builtin.debug:
+            msg: "Caught an error, but that is fine. Continuing."
+
     - name: "Get the imagebuilder image"
       ansible.builtin.include_tasks: tasks/buildimage.yml
       when: not skip_imagebuilder_build


### PR DESCRIPTION
Force the skip_imagebuilder variable to true if we find a statefile that defines imagebuilder_ami. This prevents users from having to remember to turn off imagebuilds on subsequent runs against the same pattern infrastructure