### PR TITLE
Permit only 2.4 for the time being

### DIFF
--- a/containerized_install/roles/installer/defaults/main.yml
+++ b/containerized_install/roles/installer/defaults/main.yml
@@ -46,6 +46,11 @@ eda_pg_password: "{{ db_password }}"
 eda_workers: 2
 eda_activation_workers: 2
 
+force_aap_reconfigure: false
+# These would be the defaults but we don't defined pattern_name to use the real FQDN
+#controller_hostname: "aap.{{ pattern_name }}.{{ pattern_dns_zone }}"
+controller_port: 8443
+
 # controller_license_src_file:
 # admin_password:
 # db_password:

--- a/containerized_install/roles/installer/tasks/main.yml
+++ b/containerized_install/roles/installer/tasks/main.yml
@@ -12,7 +12,7 @@
 
 - name: Run AAP Containerized installer
   when:
-    - (force_aap_reconfigure|bool) or (aap_check is failed)
+    - (force_aap_reconfigure) or (aap_check is failed)
   block:
     # https://access.redhat.com/articles/3626371#bgenerating-an-access-tokenb-4
     #
@@ -102,5 +102,3 @@
           ansible-playbook -i inventory ansible.containerized_installer.install
       async: 3600
       poll: 15
-      when:
-        - force_aap_configure or 

--- a/containerized_install/roles/installer/tasks/main.yml
+++ b/containerized_install/roles/installer/tasks/main.yml
@@ -1,89 +1,106 @@
 ---
-# https://access.redhat.com/articles/3626371#bgenerating-an-access-tokenb-4
-#
-# equivalent of 
-# curl https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token -d grant_type=refresh_token -d client_id=rhsm-api -d refresh_token=$offline_token
-- name: Generating an access token
+- name: Check to see whether AAP is already running
   ansible.builtin.uri:
-    url: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
-    method: POST
-    body_format: form-urlencoded
-    return_content: true
-    body:
-      grant_type: "refresh_token"
-      client_id: "rhsm-api"
-      refresh_token: "{{ offline_token }}"
-  register: temp_token
-  until: temp_token is not failed
-  retries: 15
-  delay: 20
+    url: 'https://127.0.0.1:{{ controller_port }}/api/v2/ping/'
+    method: GET
+    user: '{{ admin_user | default("admin") }}'
+    password: "{{ admin_password }}"
+    validate_certs: false
+  register: aap_check
+  until: aap_check.json is defined and aap_check.json.instances[0].capacity > 0 and aap_check.json.instance_groups[0].capacity > 0
+  ignore_errors: true
 
-# example sha: 0046367b76d7c3aca0d311a05935acd667438dfe9640db16f5027952d46dc470
-# curl -H "Authorization: Bearer $token"  "https://api.access.redhat.com/management/v1/images/{{ provided_sha_value }}/download"
-# curl -H "Authorization: Bearer $token"  "https://api.access.redhat.com/management/v1/images/0046367b76d7c3aca0d311a05935acd667438dfe9640db16f5027952d46dc470/download"
-- name: Download containerized installer
-  ansible.builtin.get_url:
-    url: "https://api.access.redhat.com/management/v1/images/{{ containerized_installer_shasum }}/download"
-    headers:
-      accept: "application/json"
-      Authorization: "Bearer {{ temp_token.json.access_token }}"
-    dest: "{{ containerized_installer_user_home }}/aap_installer.tar.gz"
-    checksum: "sha256: {{ containerized_installer_shasum }}"
-  register: download_installer_tarball
-  until: download_installer_tarball is not failed
-  retries: 15
-  delay: 20
+- name: Run AAP Containerized installer
+  when:
+    - (force_aap_reconfigure|bool) or (aap_check is failed)
+  block:
+    # https://access.redhat.com/articles/3626371#bgenerating-an-access-tokenb-4
+    #
+    # equivalent of
+    # curl https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token -d grant_type=refresh_token -d client_id=rhsm-api -d refresh_token=$offline_token
+    - name: Generating an access token
+      ansible.builtin.uri:
+        url: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
+        method: POST
+        body_format: form-urlencoded
+        return_content: true
+        body:
+          grant_type: "refresh_token"
+          client_id: "rhsm-api"
+          refresh_token: "{{ offline_token }}"
+      register: temp_token
+      until: temp_token is not failed
+      retries: 15
+      delay: 20
 
-- name: Extract containerized installer
-  ansible.builtin.unarchive:
-    src: "{{ containerized_installer_user_home }}/aap_installer.tar.gz"
-    dest: "{{ containerized_installer_user_home }}"
-    owner: "{{ containerized_installer_user }}"
-    group: "{{ containerized_installer_user }}"
-    remote_src: true
+    # example sha: 0046367b76d7c3aca0d311a05935acd667438dfe9640db16f5027952d46dc470
+    # curl -H "Authorization: Bearer $token"  "https://api.access.redhat.com/management/v1/images/{{ provided_sha_value }}/download"
+    # curl -H "Authorization: Bearer $token"  "https://api.access.redhat.com/management/v1/images/0046367b76d7c3aca0d311a05935acd667438dfe9640db16f5027952d46dc470/download"
+    - name: Download containerized installer
+      ansible.builtin.get_url:
+        url: "https://api.access.redhat.com/management/v1/images/{{ containerized_installer_shasum }}/download"
+        headers:
+          accept: "application/json"
+          Authorization: "Bearer {{ temp_token.json.access_token }}"
+        dest: "{{ containerized_installer_user_home }}/aap_installer.tar.gz"
+        checksum: "sha256: {{ containerized_installer_shasum }}"
+      register: download_installer_tarball
+      until: download_installer_tarball is not failed
+      retries: 15
+      delay: 20
 
-- name: Determine install directory
-  ansible.builtin.find:
-    paths: "{{ containerized_installer_user_home }}"
-    file_type: directory
-    use_regex: true
-    patterns:
-      - 'ansible-automation-platform-containerized-setup'
-  register: aap_directories
+    - name: Extract containerized installer
+      ansible.builtin.unarchive:
+        src: "{{ containerized_installer_user_home }}/aap_installer.tar.gz"
+        dest: "{{ containerized_installer_user_home }}"
+        owner: "{{ containerized_installer_user }}"
+        group: "{{ containerized_installer_user }}"
+        remote_src: true
 
-- name: Set directory fact
-  ansible.builtin.set_fact:
-    aap_installer_dir: "{{ (aap_directories.files | sort(attribute='mtime', reverse=true) | first).path }}"
+    - name: Determine install directory
+      ansible.builtin.find:
+        paths: "{{ containerized_installer_user_home }}"
+        file_type: directory
+        use_regex: true
+        patterns:
+          - 'ansible-automation-platform-containerized-setup'
+      register: aap_directories
 
-- name: Determine controller_fqdn from inside the user environment
-  ansible.builtin.command: |-
-    hostname -f
-  register: local_hostname
+    - name: Set directory fact
+      ansible.builtin.set_fact:
+        aap_installer_dir: "{{ (aap_directories.files | sort(attribute='mtime', reverse=true) | first).path }}"
 
-- name: Set controller_fqdn to local hostname
-  ansible.builtin.set_fact:
-    controller_fqdn: "{{ local_hostname.stdout | trim }}"
+    - name: Determine controller_fqdn from inside the user environment
+      ansible.builtin.command: |-
+        hostname -f
+      register: local_hostname
 
-- name: Template inventory file
-  ansible.builtin.template:
-    src: containerized_install_inventory.j2
-    dest: "{{ aap_installer_dir }}/inventory"
-    owner: "{{ containerized_installer_user }}"
-    group: "{{ containerized_installer_user }}"
-    mode: "0600"
+    - name: Set controller_fqdn to local hostname
+      ansible.builtin.set_fact:
+        controller_fqdn: "{{ local_hostname.stdout | trim }}"
 
-- name: Copy manifest
-  ansible.builtin.copy:
-    content: "{{ manifest_content | b64decode }}"
-    dest: "{{ controller_license_file }}"
-    owner: "{{ containerized_installer_user }}"
-    group: "{{ containerized_installer_user }}"
-    mode: "0600"
+    - name: Template inventory file
+      ansible.builtin.template:
+        src: containerized_install_inventory.j2
+        dest: "{{ aap_installer_dir }}/inventory"
+        owner: "{{ containerized_installer_user }}"
+        group: "{{ containerized_installer_user }}"
+        mode: "0600"
 
-- name: Run containerized installer
-  ansible.builtin.command:
-    chdir: "{{ aap_installer_dir }}"
-    cmd: |-
-      ansible-playbook -i inventory ansible.containerized_installer.install
-  async: 3600
-  poll: 15
+    - name: Copy manifest
+      ansible.builtin.copy:
+        content: "{{ manifest_content | b64decode }}"
+        dest: "{{ controller_license_file }}"
+        owner: "{{ containerized_installer_user }}"
+        group: "{{ containerized_installer_user }}"
+        mode: "0600"
+
+    - name: Run containerized installer
+      ansible.builtin.command:
+        chdir: "{{ aap_installer_dir }}"
+        cmd: |-
+          ansible-playbook -i inventory ansible.containerized_installer.install
+      async: 3600
+      poll: 15
+      when:
+        - force_aap_configure or 

--- a/init_env/pre_init_env.yml
+++ b/init_env/pre_init_env.yml
@@ -8,6 +8,11 @@
     - "./vars/init_env_vars.yml"
     - "~/agof_vault.yml"
   tasks:
+    - name: Ensure we can proceed
+      ansible.builtin.assert:
+        that: aap_version == '2.4'
+        fail_msg: "aap_version {{ aap_version }} not (yet) supported. Must be 2.4"
+
     - name: "Write ansible.cfg"
       ansible.builtin.template:
         src: ansible.cfg.j2
@@ -25,7 +30,12 @@
 
         - name: "Install requirements file based collections {{ 'forcefully' if init_env_collection_install_force }}"
           ansible.builtin.command:
-            cmd: "ansible-galaxy collection install {{ '--force' if init_env_collection_install_force }} -p '{{ ansible_cfg_patch_collection_dir }}' -r requirements.yml"
+            cmd: |-
+              {% if aap_version < '2.5' %}
+              ansible-galaxy collection install {{ '--force' if init_env_collection_install_force }} -p '{{ ansible_cfg_patch_collection_dir }}' -r requirements.yml.pre25
+              {% else %}
+              ansible-galaxy collection install {{ '--force' if init_env_collection_install_force }} -p '{{ ansible_cfg_patch_collection_dir }}' -r requirements.yml
+              {% endif %}
             chdir: ".."
           environment:
             ANSIBLE_GALAXY_SERVER_AUTOMATION_HUB_CERTIFIED_TOKEN: "{{ automation_hub_token }}"

--- a/init_env/vars/init_env_vars.yml
+++ b/init_env/vars/init_env_vars.yml
@@ -14,6 +14,7 @@ automation_hub_url: '{{ automation_hub_url_vault }}'
 automation_hub_token: '{{ automation_hub_token_vault }}'
 
 init_env_collection_install: true
-init_env_collection_install_force: false
+init_env_collection_install_force: true
+aap_version: '2.4'
 
 special_collection_installs: []

--- a/requirements.yml.pre25
+++ b/requirements.yml.pre25
@@ -1,0 +1,22 @@
+# vim: ft=yaml
+---
+# These are the collections required by the builder
+collections:
+- amazon.aws
+- awx.awx
+- name: ansible.controller
+  version: '<4.6.0'
+- ansible.netcommon
+- ansible.posix
+- ansible.utils
+- community.aws
+- community.general
+- containers.podman
+- infra.ah_configuration
+- infra.controller_configuration
+- infra.eda_configuration
+- redhat.rhel_idm
+- redhat.rhel_system_roles
+- redhat.satellite
+- redhat.satellite_operations
+- redhat.redhat_csp_download

--- a/site.yml
+++ b/site.yml
@@ -7,10 +7,25 @@
   vars_files:
     - 'vars/main.yml'
     - '~/agof_vault.yml'
+  vars:
+    aap_version: '2.4'
+    init_env_collection_install_force: true
   tasks:
+    - name: Ensure we can proceed
+      ansible.builtin.assert:
+        that:
+          - aap_version == '2.4'
+        fail_msg: "aap_version {{ aap_version }} not (yet) supported. Must be 2.4"
+
     - name: "Show vars"
       ansible.builtin.debug:
-        msg: 'build_idm: {{ build_idm }} / build_sat: {{ build_sat }} / automation_hub: {{ automation_hub }} / eda: {{ eda }} / containerized_install: {{ containerized_install }}'
+        msg:
+          - "aap_version: {{ aap_version }}"
+          - "build_idm: {{ build_idm }}"
+          - "build_sat: {{ build_sat }}"
+          - "automation_hub: {{ automation_hub }}"
+          - "eda: {{ eda }}"
+          - "containerized_install: {{ containerized_install }}"
 
     - name: "Set controller port for containerized_install"
       ansible.builtin.set_fact:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -10,3 +10,4 @@ containerized_install_user: 'aap'
 containerized_install_user_home: '/var/lib/aap'
 
 aap_version: "2.4"
+init_env_collection_install_force: true


### PR DESCRIPTION
Infrastructure as Code collections still have some gaps for the 2.5 release. This should be remedied with the next point release, but in the meantime there are a few too many sharp edges to run with the original scheme.