### PR TITLE
Remove makefile duplication and refactor waitfor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ preinit: ## Setup ansible environemnt - configure ansible.cfg and download colle
 fix_aws_dns: ## Update public DNS for AWS - needed when a VM cold starts
 	ansible-playbook init_env/aws/fix_aws_dns.yml $(EXTRA_PLAYBOOK_OPTS)
 
-install: preinit ## Install the pattern - including bootstrapping an AWS environment to run it in
+install: ## Install the pattern - including bootstrapping an AWS environment to run it in
 	ansible-playbook site.yml $(EXTRA_PLAYBOOK_OPTS)
 
 aws_uninstall: ## Uninstall the AWS environment for the pattern, including its DNS entries

--- a/init_env/aws/main.yml
+++ b/init_env/aws/main.yml
@@ -80,6 +80,19 @@
       vars:
         ami_id: "{{ copied_ami | default(imagebuilder_ami) }}"
 
+- name: Ensure AWS nodes are ready for post-provisioning
+  hosts: aws_nodes
+  become: true
+  gather_facts: false
+  vars_files:
+    - "vars/aws_vars.yml"
+    - "~/agof_vault.yml"
+  tasks:
+    - name: "Wait for VM(s) to be ready for SSH"
+      ansible.builtin.wait_for:
+        port: 22
+        search_regex: OpenSSH
+
 - name: Post-provisioning tasks
   hosts: aws_nodes
   become: true
@@ -91,11 +104,6 @@
     ec2_instances_built: "{{ hostvars['localhost']['ec2_instances_built'] }}"
     ipaclient_configure_dns_resolver: false
   tasks:
-    - name: "Wait for VM(s) to be ready for SSH"
-      ansible.builtin.wait_for:
-        port: 22
-        search_regex: OpenSSH
-
     - name: "Ensure remote tmp directory"
       ansible.builtin.file:
         path: '{{ aws_remote_tmp }}'


### PR DESCRIPTION
Fixes #29 

This moves the waitfor task to its own play without gather_facts to ensure that any built nodes have time to come up.

This also (unrelated) removes a duplication in the Makefile that causes pre-init to run twice (only once is needed).