### PR TITLE
Limit validation play to localhost explicitly

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -1,6 +1,6 @@
 ---
 - name: "Pre-install: validate values and variables"
-  hosts: build_control
+  hosts: localhost
   become: false
   gather_facts: false
   connection: local


### PR DESCRIPTION
Previously, pre-init would be called explicitly, which would create an ansible.cfg which would point to an inventory that had build_control defined.

Since the validation play only requires localhost, use that explicitly to avoid this problem.