### PR TITLE
Reinstate dependency on preinit in install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ preinit: ## Setup ansible environemnt - configure ansible.cfg and download colle
 fix_aws_dns: ## Update public DNS for AWS - needed when a VM cold starts
 	ansible-playbook init_env/aws/fix_aws_dns.yml $(EXTRA_PLAYBOOK_OPTS)
 
-install: ## Install the pattern - including bootstrapping an AWS environment to run it in
+install: preinit ## Install the pattern - including bootstrapping an AWS environment to run it in
 	ansible-playbook site.yml $(EXTRA_PLAYBOOK_OPTS)
 
 aws_uninstall: ## Uninstall the AWS environment for the pattern, including its DNS entries


### PR DESCRIPTION
This ensures that ansible.cfg is present and readable for the install run. It will fail otherwise the first time it is run