### PR TITLE
Add initial jwt checking playbook

### DIFF
--- a/pre_init/jwt_check.yml
+++ b/pre_init/jwt_check.yml
@@ -1,0 +1,73 @@
+# This playbook gets a token name, its content and and a duration as
+# parameters, looks for the iat claim and prints a warning if the token
+# is older than the duration.
+# The parameters are:
+# `local_token_name`: a name for the token that is being examined
+# `local_token`: the JWT token that is to be examined
+# `local_token_duration_days`: Duration in days 30
+#
+# If the `iat` timestamp + `local_token_duration` is > than the current time then a
+# warning is emitted.
+#
+# A jwt token is split in three base64-encoded strings separated by a '.'
+# The middle one [1] is the json with the claims. The claim we try and look up is 'iat'
+# We do not use the jwt collections as we do not want to add another non-core dependency
+---
+- name: Set local_token_duration_days when not defined
+  ansible.builtin.set_fact:
+    local_token_duration_days: 30
+  when: local_token_duration_days is not defined
+
+- name: Assert that the parameters are set
+  ansible.builtin.assert:
+    that:
+      - local_token_name is defined
+      - local_token is defined
+      - local_token_duration_days is defined
+      - local_token_duration_days | type_debug == "int"
+
+- name: Get some local facts including current time
+  ansible.builtin.setup: # Needed for ansible_date_time
+    gather_subset:
+      - min
+
+- name: Get the claims part of the JWT
+  ansible.builtin.set_fact:
+    jwt_raw: "{{ local_token.split('.')[1] }}"
+
+- name: Calculate the duration in seconds
+  ansible.builtin.set_fact:
+    local_token_duration: "{{ local_token_duration_days * 24 * 60 * 60 | int }}"
+
+- name: Add padding if needed
+  ansible.builtin.set_fact:
+    jwt_raw: "{{ jwt_raw + '=' * (4 - (jwt_raw | length) % 4) if (jwt_raw | length) % 4 != 0 else jwt_raw }}"
+
+- name: Base64 decode and parse the json
+  ansible.builtin.set_fact:
+    jwt_claims: "{{ jwt_raw | b64decode | from_json }}"
+
+- name: Set IAT variable if it exists
+  ansible.builtin.set_fact:
+    jwt_iat: "{{ jwt_claims['iat'] }}"
+  when: "'iat' in jwt_claims"
+
+- name: Set IAT timestamp + {{ local_token_duration }}
+  ansible.builtin.set_fact:
+    iat_after_duration: "{{ jwt_iat | int + local_token_duration | int }}"
+  when: "'iat' in jwt_claims"
+
+- name: Validity is still good
+  ansible.builtin.debug:
+    msg: "The {{ local_token_name }} token was issued at {{ '%Y-%m-%d %H:%M' | strftime(jwt_iat) }}, and is still good"
+  when: (iat_after_duration | int >= ansible_date_time['epoch'] | int)
+
+# Note: This is a hack because ansible does not have a simple warning statement without pulling in custom
+# callbacks, python code and what not. See https://www.github.com/ansible/ansible/issues/67260
+- name: Token is not valid any longer
+  ansible.builtin.fail:
+    msg: >
+      "The {{ local_token_name }} token was generated more than 30 days ago {{ '%Y-%m-%d %H:%M' | strftime(jwt_iat) }}, "
+      "you should renew your token. We're continuing, but chances are there might be issues with the token."
+  when: (iat_after_duration | int < ansible_date_time['epoch'] | int)
+  ignore_errors: true

--- a/pre_init/main.yml
+++ b/pre_init/main.yml
@@ -14,6 +14,20 @@
         dest: '../ansible.cfg'
         mode: '0600'
 
+    - name: Check if offline token is older than 30 days
+      ansible.builtin.import_tasks: jwt_check.yml
+      vars:
+        local_token_name: "offline_token"
+        local_token: "{{ offline_token }}"
+      failed_when: false
+
+    - name: Check if automation_hub_token is older than 30 days
+      ansible.builtin.import_tasks: jwt_check.yml
+      vars:
+        local_token_name: "automation_hub_token"
+        local_token: "{{ automation_hub_token }}"
+      failed_when: false
+
     - name: "Install collections for ansible environment {{ 'forcefully' if init_env_collection_install_force }}"
       when: init_env_collection_install
       block:


### PR DESCRIPTION
This change introduces a playbook to check for the time validity of a
JWT token. It takes three parameters: local_token_name, local_token and
local_token_days (defaults to 30).

It will print out the following then the token is not valid (note that
it won't fail):

    ❯ ANSIBLE_STDOUT_CALLBACK="community.general.unixy" ansible-playbook wrapper.yml -e local_token_name="Offline token" -e local_token="$(cat ~/.ansible-hub-token.old)"
    [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
    Executing playbook jwt-check.yml

    - Check JWT time validity on hosts: localhost -
    Assert that the parameters are set...
      localhost ok: {
        "changed": false,
        "msg": "All assertions passed"
    }
    Get some local facts including current time...
      localhost ok
    Get the claims part of the JWT...
      localhost ok
    Calculate the duration in seconds...
      localhost ok
    Add padding if needed...
      localhost ok
    Base64 decode and parse the json...
      localhost ok
    Set IAT variable if it exists...
      localhost ok
    Set IAT timestamp + 2592000...
      localhost ok
    Validity is still good...
      localhost skipped
    Token is not valid any longer...
      localhost failed | msg: The Offline token was generated more than 30 days ago 2023-10-10 17:22, you should renew your token. We're continuing, but chances are there might be issues with the token.

When the token is valid it will print out the following:

    - Play recap -
      localhost                  : ok=9    changed=0    unreachable=0    failed=0    rescued=0    ignored=1
    ❯ ANSIBLE_STDOUT_CALLBACK="community.general.unixy" ansible-playbook wrapper.yml -e local_token_name="Offline token" -e local_token="$(cat ~/.ansible-hub-token)"
    [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
    Executing playbook jwt-check.yml

    - Check JWT time validity on hosts: localhost -
    Assert that the parameters are set...
      localhost ok: {
        "changed": false,
        "msg": "All assertions passed"
    }
    Get some local facts including current time...
      localhost ok
    Get the claims part of the JWT...
      localhost ok
    Calculate the duration in seconds...
      localhost ok
    Add padding if needed...
      localhost ok
    Base64 decode and parse the json...
      localhost ok
    Set IAT variable if it exists...
      localhost ok
    Set IAT timestamp + 2592000...
      localhost ok
    Validity is still good...
      localhost ok: {
        "changed": false,
        "msg": "The Offline token was issued at 2024-11-08 16:52, and is still good"
    }
    Token is not valid any longer...
      localhost skipped

    - Play recap -
      localhost                  : ok=9    changed=0    unreachable=0    failed=0    rescued=0    ignored=0

We also add `failed_when: false` to both invocations, because 1) we do
not want to fail in case our JWT parsing is missing some corner cases
and 2) One of the two facts might not be required in a special case
installation.
