### PR TITLE
Make agof_vault effectively optional for OpenShift

### DIFF
--- a/pre_init/main.yml
+++ b/pre_init/main.yml
@@ -20,6 +20,8 @@
         local_token_name: "offline_token"
         local_token: "{{ offline_token }}"
       failed_when: false
+      when:
+        - offline_token is defined
 
     - name: Check if automation_hub_token is older than 30 days
       ansible.builtin.import_tasks: jwt_check.yml
@@ -27,6 +29,8 @@
         local_token_name: "automation_hub_token"
         local_token: "{{ automation_hub_token }}"
       failed_when: false
+      when:
+        - automation_hub_token is defined
 
     - name: "Install collections for ansible environment {{ 'forcefully' if init_env_collection_install_force }}"
       when: init_env_collection_install

--- a/pre_init/openshift_vp_preinit.yml
+++ b/pre_init/openshift_vp_preinit.yml
@@ -7,6 +7,8 @@
   gather_facts: false
   vars:
     kubeconfig: "{{ lookup('env', 'KUBECONFIG') }}"
+    agof_controller_config_dir: "{{ '~/agofdir' | expanduser }}"
+    agof_statedir: "{{ '~/agof' | expanduser }}"
   tasks:
     - name: Retrieve IAC Repo Details
       kubernetes.core.k8s_info:

--- a/pre_init/openshift_vp_preinit.yml
+++ b/pre_init/openshift_vp_preinit.yml
@@ -31,6 +31,20 @@
           - "agof_iac_repo: {{ agof_iac_repo }}"
           - "agof_iac_repo_version: {{ agof_iac_repo_version }}"
 
+    - name: Retrieve automation hub token
+      kubernetes.core.k8s_info:
+        kind: Secret
+        namespace: aap-config
+        name: automation-hub-token
+      register: automation_hub_token_secret
+      until: automation_hub_token_secret.resources | length == 1
+      retries: 20
+      delay: 5
+
+    - name: Set automation hub token fact
+      ansible.builtin.set_fact:
+        automation_hub_token_vault: "{{ automation_hub_token_secret.resources[0].data.token | b64decode }}"
+
     - name: Retrieve manifest file
       kubernetes.core.k8s_info:
         kind: Secret

--- a/pre_init/openshift_vp_preinit.yml
+++ b/pre_init/openshift_vp_preinit.yml
@@ -7,8 +7,6 @@
   gather_facts: false
   vars:
     kubeconfig: "{{ lookup('env', 'KUBECONFIG') }}"
-    agof_controller_config_dir: "{{ '~/agofdir' | expanduser }}"
-    agof_statedir: "{{ '~/agof' | expanduser }}"
   tasks:
     - name: Retrieve IAC Repo Details
       kubernetes.core.k8s_info:
@@ -107,7 +105,7 @@
           vault_root_token: "{{ vault_data.root_token  }}"
           vault_url: https://vault.vault.svc:8200
 
-- name: Retrieve Credentials for AAP on OpenShift
+- name: Retrieve Credentials for AAP on OpenShift and write needed override files
   become: false
   connection: local
   hosts: localhost
@@ -115,6 +113,8 @@
   vars:
     kubeconfig: "{{ lookup('env', 'KUBECONFIG') }}"
     aap_entitled: false
+    agof_controller_config_dir: "{{ '~/agofdir' | expanduser }}"
+    agof_statedir: "{{ '~/agof' | expanduser }}"
   tasks:
     - name: Retrieve API hostname for AAP
       kubernetes.core.k8s_info:

--- a/pre_init/templates/agof_overrides.yml.j2
+++ b/pre_init/templates/agof_overrides.yml.j2
@@ -1,6 +1,9 @@
 ---
 aap_entitled: {{ aap_entitled | string | lower }}
 
+agof_controller_config_dir: "{{ agof_controller_config_dir }}"
+agof_statedir: "{{ agof_statedir }}"
+
 admin_user: admin
 admin_password: "{{ admin_password }}"
 

--- a/pre_init/templates/agof_overrides.yml.j2
+++ b/pre_init/templates/agof_overrides.yml.j2
@@ -12,6 +12,8 @@ aap_validate_certs: false
 agof_iac_repo: "{{ agof_iac_repo }}"
 agof_iac_repo_version: "{{ agof_iac_repo_version }}"
 
+automation_hub_token_vault: "{{ automation_hub_token_vault }}"
+
 controller_license_src_file: "{{ manifest_file_ref }}"
 
 secrets: {{ secrets | to_json }}


### PR DESCRIPTION
Define defaults for the infrastructure components of AAP needed for AGOF. This means that an agof_vault for openshift can then only include secrets to be included in an AGOF-on-openshift pattern.

This also surfaces the need to define the automation hub token as a requirement for the aap-config chart.

We also make the token existence optional for the time check as we don't need the offline token for AAP-on-OpenShift installs.