### PR TITLE
Trim the string when parsing the secret

### DIFF
--- a/pre_init/openshift_vp_preinit.yml
+++ b/pre_init/openshift_vp_preinit.yml
@@ -43,7 +43,7 @@
 
     - name: Set automation hub token fact
       ansible.builtin.set_fact:
-        automation_hub_token_vault: "{{ automation_hub_token_secret.resources[0].data.token | b64decode }}"
+        automation_hub_token_vault: "{{ automation_hub_token_secret.resources[0].data.token | b64decode | trim }}"
 
     - name: Retrieve manifest file
       kubernetes.core.k8s_info:


### PR DESCRIPTION
Reason for this is that otherwise you will likely get a newline at the
end of the string. This newline then will get eventually end up being a
blank character and trip up the authenticaction when calling
ansible-galaxy.

A verbose run will show a newline:
TASK [Set automation hub token fact] *******************************************
task path: /pattern-home/agof_repo/pre_init/openshift_vp_preinit.yml:44
ok: [localhost] => {
    "ansible_facts": {
        "automation_hub_token_vault": "e....f0Z\n"
    },
    "changed": false
}

and the ansible-galaxy command will fail as follows:

"stderr_lines": [
        "[WARNING]: Skipping Galaxy server https://console.redhat.com/api/automation-",
        "hub/content/published/. Got an unexpected error when getting available versions",
        "of collection infra.aap_configuration: HTTP Error 400: Bad Request",
        "[WARNING]: Skipping Galaxy server https://console.redhat.com/api/automation-",
        "hub/content/validated/. Got an unexpected error when getting available versions",
        "of collection infra.aap_configuration: HTTP Error 400: Bad Request",
        "[WARNING]: Skipping Galaxy server https://console.redhat.com/api/automation-",
        "hub/content/published/. Got an unexpected error when getting available versions",
        "of collection ansible.platform: HTTP Error 400: Bad Request",
        "[WARNING]: Skipping Galaxy server https://console.redhat.com/api/automation-",
        "hub/content/validated/. Got an unexpected error when getting available versions",
        "of collection ansible.platform: HTTP Error 400: Bad Request",
        "ERROR! Failed to resolve the requested dependencies map. Could not satisfy the following requirements:",
        "* ansible.platform:* (direct request)",
        "Hint: Pre-releases hosted on Galaxy or Automation Hub are not installed by default unles

Because the extra character at the end will mess with the
authentication.

With this change we went from consistently failing the ansible-galaxy
collection install to passing it.
