### PR TITLE
Fix error when agof_iac_repo_version is not defined

### DIFF
--- a/agof_configure_aap/roles/configure_aap/tasks/main.yml
+++ b/agof_configure_aap/roles/configure_aap/tasks/main.yml
@@ -19,7 +19,7 @@
   ansible.builtin.debug:
     msg:
       - "agof_iac_repo: {{ agof_iac_repo }}"
-      - "agof_iac_repo_version: {{ agof_iac_repo_version }}"
+      - "agof_iac_repo_version: {{ agof_iac_repo_version | default('main') }}"
       - "Checked out to: {{ agof_controller_config_dir }}"
       - "Git SHA before checkout: {{ git_checkout.before }}"
       - "Git SHA after checkout: {{ git_checkout.after }}"


### PR DESCRIPTION
If `agof_iac_repo_version` fact is not defined it should default to
`main`, but there is a task that does not use that default and it will
fail as follows:

    TASK [agof_configure_aap/roles/configure_aap : Show Git coordinates] ************************************************************************************************************************************************************
    fatal: [localhost]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'agof_iac_repo_version' is undefined. 'agof_iac_repo_version' is undefined\n\nThe error appears to be in '/home/michele/agof-walkthrough/agof/ag
    of_configure_aap/roles/configure_aap/tasks/main.yml': line 18, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Show Git coordinates\n  ^ here\n"}

Fix this by using the `main` default when printing those git
coordinates.
