### PR TITLE
Strengthen test of whether we should perform config fixups

### DIFF
--- a/agof_configure_aap/roles/configure_aap/tasks/main.yml
+++ b/agof_configure_aap/roles/configure_aap/tasks/main.yml
@@ -113,7 +113,7 @@
     - agof_configure_aap_debug
 
 - name: Perform any necessary pre-config fixups
-  when: perform_pre_config_fixups
+  when: (perform_pre_config_fixups|bool) is true
   block:
     - name: Pre-config fixes
       ansible.builtin.include_role:


### PR DESCRIPTION
The previous version of the test for running pre-config always returned true. The explicit cast allows it to return false and be skipped.