### PR TITLE
Set a default ec2_name_prefix

### DIFF
--- a/agof_configure_aap/roles/configure_aap/defaults/main.yml
+++ b/agof_configure_aap/roles/configure_aap/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 automation_hub: false
 
+ec2_name_prefix: "agof-vp-{{ (ansible_user_id | default('user'))[:5] }}"
+
 pattern_name: '{{ ec2_name_prefix }}'
 
 aap_hostname: 'aap.{{ pattern_name }}.{{ pattern_dns_zone }}'


### PR DESCRIPTION
Since it is not a required field, let's set a reasonable default.
We also put of the username as well to avoid potential clashes on
cloud infrastructure if multiple users are using the same cloud/region.
