### PR TITLE
agof_statedir is not used anywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,9 @@ Automation Hub and EDA are enabled by default, but they can be turned off if des
 By default, the framework will apply license content specified by the `manifest_content` variable, but will not further configure Controller or Automation Hub beyond the defaults.
 
 From there, a minimal example pattern is available to download and run [here](https://github.com/validatedpatterns-demos/agof_minimal_config.git). To use this example, set the following variables in your `agof_vault.yml`.
-`agof_statedir` is where the config repo will be checked out by the process. Any repo that can be used with the controller_configuration collection can be used as the `agof_iac_repo`.
+Any repo that can be used with the controller_configuration collection can be used as the `agof_iac_repo`.
 
 ```yaml
-agof_statedir: "{{ '~/agof' | expanduser }}"
 agof_iac_repo: "https://github.com/validatedpatterns-demos/agof_minimal_config.git"
 ```
 

--- a/pre_init/openshift_vp_preinit.yml
+++ b/pre_init/openshift_vp_preinit.yml
@@ -114,7 +114,6 @@
     kubeconfig: "{{ lookup('env', 'KUBECONFIG') }}"
     aap_entitled: false
     agof_controller_config_dir: "{{ '~/agofdir' | expanduser }}"
-    agof_statedir: "{{ '~/agof' | expanduser }}"
   tasks:
     - name: Retrieve API hostname for AAP
       kubernetes.core.k8s_info:

--- a/pre_init/templates/agof_overrides.yml.j2
+++ b/pre_init/templates/agof_overrides.yml.j2
@@ -2,7 +2,6 @@
 aap_entitled: {{ aap_entitled | string | lower }}
 
 agof_controller_config_dir: "{{ agof_controller_config_dir }}"
-agof_statedir: "{{ agof_statedir }}"
 
 admin_user: admin
 admin_password: "{{ admin_password }}"


### PR DESCRIPTION
Let's just drop it as it is currently not used anywhere.
(Tested on my deployment)
