### PR TITLE
Some cleanups

### DIFF
--- a/agof_configure_aap/roles/configure_aap/defaults/main.yml
+++ b/agof_configure_aap/roles/configure_aap/defaults/main.yml
@@ -7,8 +7,6 @@ aap_hostname: 'aap.{{ pattern_name }}.{{ pattern_dns_zone }}'
 
 api_prefix: api/controller/v2
 
-controller_state: present
-
 agof_configure_aap_debug: false
 aap_request_timeout: 90
 aap_configuration_async_dir: /tmp/.ansible_async

--- a/agof_configure_aap/roles/configure_aap/tasks/main.yml
+++ b/agof_configure_aap/roles/configure_aap/tasks/main.yml
@@ -113,11 +113,9 @@
     - agof_configure_aap_debug
 
 - name: Perform any necessary pre-config fixups
-  when: (perform_pre_config_fixups|bool) is true
-  block:
-    - name: Pre-config fixes
-      ansible.builtin.include_role:
-        name: agof_configure_aap/roles/pre_config_fixups
+  when: perform_pre_config_fixups | bool
+  ansible.builtin.include_role:
+    name: agof_configure_aap/roles/pre_config_fixups
 
 - name: "Configure AAP - Version 2.5+"
   block:

--- a/agof_configure_aap/roles/configure_aap/tasks/main.yml
+++ b/agof_configure_aap/roles/configure_aap/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: Debug
+- name: Show AAP hostname
   ansible.builtin.debug:
     msg:
       - "aap_hostname: {{ aap_hostname }}"

--- a/agof_configure_aap/roles/pre_config_fixups/filter_plugins/filters.py
+++ b/agof_configure_aap/roles/pre_config_fixups/filter_plugins/filters.py
@@ -12,13 +12,12 @@ class FilterModule(object):
             return enabled_activations
 
         for a in activations:
-            enabled = False
-            try:
-                a.get('enabled')
+            if 'enabled' in a:
+                enabled = bool(a['enabled'])
+            elif a.get('state', 'present') in ["present", "enabled"]:
                 enabled = True
-            except IndexError:
-                if a.get('state', 'present') in ["present", "enabled"]:
-                    enabled = True
+            else:
+                enabled = False
 
             if enabled:
                 enabled_activations.append(a.get('name'))

--- a/agof_configure_aap/roles/pre_config_fixups/tasks/rulebook_activations.yml
+++ b/agof_configure_aap/roles/pre_config_fixups/tasks/rulebook_activations.yml
@@ -8,12 +8,9 @@
       ansible.builtin.debug:
         var: eda_rulebook_activations
 
-    - name: Default set of rulebook activations to stop to empty
+    - name: Initialize activation tracking variables
       ansible.builtin.set_fact:
         rulebook_activations_to_disable: []
-
-    - name: Determine whether we have any enabled activations due to configure
-      ansible.builtin.set_fact:
         enabled_activation_names: "{{ eda_rulebook_activations | activations_to_enable | list }}"
 
     - name: Retrieve existing rulebook activation configs

--- a/init_env/aws/roles/aws_check_setup/tasks/main.yml
+++ b/init_env/aws/roles/aws_check_setup/tasks/main.yml
@@ -1,19 +1,19 @@
 ---
 - name: make sure we are running correct Ansible Version
-  assert:
+  ansible.builtin.assert:
     that:
       - ansible_version.major >= 2
       - ansible_version.minor >= 11
 
 - name: make sure dns_type is set to a correct value
-  assert:
+  ansible.builtin.assert:
     that:
       - dns_type is defined
       - dns_type in valid_dns_type
     msg: "dns_type must be defined and be one of: {{ valid_dns_type }}"
 
 - name: make sure we are not running with TESTPATTERN as the name so no overlap
-  assert:
+  ansible.builtin.assert:
     that:
       - ec2_name_prefix != "TESTPATTERN"
     msg:
@@ -21,7 +21,7 @@
       - "please set a unique name for your pattern"
 
 - name: make sure we are not using `ansible` as the password
-  assert:
+  ansible.builtin.assert:
     that:
       - admin_password != "ansible"
     msg:
@@ -35,7 +35,7 @@
   when: dns_type == "aws"
   block:
     - name: check for underscores in pattern name
-      fail:
+      ansible.builtin.fail:
         msg: "Amazon AWS does not allow underscores _ for s3 websites, please see https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html"
       when:
         - "'_' in ec2_name_prefix"
@@ -48,7 +48,7 @@
       register: test
 
     - name: make sure pattern_dns_zone is owned by your account
-      assert:
+      ansible.builtin.assert:
         that:
           - test.zone_id is not none
         msg:
@@ -62,7 +62,7 @@
   until: az_names is not failed
 
 - name: Remove any AZs in the aws_az_deny_list when defined
-  set_fact:
+  ansible.builtin.set_fact:
     availability_zones: >-
       {{ az_names.availability_zones | json_query(__filter_query) }}
   vars:
@@ -70,12 +70,12 @@
       [?!contains(`{{ (aws_az_deny_list | default([])) | to_json }}`, zone_name)]
 
 - name: Output AWS Availability Zones (AZs)
-  debug:
+  ansible.builtin.debug:
     var: availability_zones
     verbosity: 2
 
 - name: SET AZ ZONE TO FIRST AVAILABLE
-  set_fact:
+  ansible.builtin.set_fact:
     ec2_az: "{{ availability_zones[0].zone_name }}"
 
 - name: grab information about AWS user
@@ -84,10 +84,10 @@
   register: whoami
 
 - name: print whoami
-  debug:
+  ansible.builtin.debug:
     var: whoami
 
 - name: save AWS user details
-  set_fact:
+  ansible.builtin.set_fact:
     aws_user: '{{ whoami.arn.split("/")[-1] }}'
     aws_account: '{{ whoami.account }}'

--- a/init_env/aws/roles/aws_check_setup/tasks/main.yml
+++ b/init_env/aws/roles/aws_check_setup/tasks/main.yml
@@ -87,10 +87,7 @@
   debug:
     var: whoami
 
-- name: save username of AWS user
+- name: save AWS user details
   set_fact:
     aws_user: '{{ whoami.arn.split("/")[-1] }}'
-
-- name: save account id of AWS user
-  set_fact:
     aws_account: '{{ whoami.account }}'

--- a/init_env/aws/roles/manage_ec2_infra/tasks/main.yml
+++ b/init_env/aws/roles/manage_ec2_infra/tasks/main.yml
@@ -3,6 +3,6 @@
   when: teardown|bool
 
 - name: provision aws resources and instances
-  include_tasks: provision.yml
+  ansible.builtin.include_tasks: provision.yml
   tags: provisioned
   when: not teardown|bool

--- a/init_env/aws/roles/manage_ec2_infra/tasks/provision.yml
+++ b/init_env/aws/roles/manage_ec2_infra/tasks/provision.yml
@@ -1,10 +1,10 @@
 ---
 - name: ensure workshop folder {{ ec2_name_prefix }} exists
-  file:
+  ansible.builtin.file:
     path: "{{ pattern_state_rootdir }}/{{ ec2_name_prefix }}"
     state: directory
 
 ## These AWS resources are used for every workshop type
 ## This includes VPC, subnet, Security Group, Internet Gateway and route table
 - name: provision aws resources
-  include_tasks: resources/resources.yml
+  ansible.builtin.include_tasks: resources/resources.yml

--- a/init_env/aws/roles/manage_ec2_infra/tasks/resources/none.yml
+++ b/init_env/aws/roles/manage_ec2_infra/tasks/resources/none.yml
@@ -1,4 +1,4 @@
 ---
 - name: dns_type set to none, not using any cloud for backup
-  debug:
+  ansible.builtin.debug:
     msg: "dns_type set to none, not using any cloud for backup"

--- a/init_env/aws/roles/manage_ec2_infra/tasks/resources/resources.yml
+++ b/init_env/aws/roles/manage_ec2_infra/tasks/resources/resources.yml
@@ -15,7 +15,7 @@
   retries: 5
 
 - name: Create file for all AWS security group rules
-  template:
+  ansible.builtin.template:
     src: vpc_rules.j2
     dest: "{{pattern_state_rootdir}}/{{ec2_name_prefix}}/aws_rules.yml"
   delegate_to: localhost
@@ -92,7 +92,7 @@
   retries: 5
 
 - name: set variables for instance creation
-  set_fact:
+  ansible.builtin.set_fact:
     ec2_vpc_id: "{{ create_vpc.vpc.id }}"
     ec2_security_group: "{{ ec2_name_prefix }}-insecure_all"
     ec2_vpc_subnet_id: "{{ create_subnet.subnet.id }}"

--- a/init_env/aws/roles/manage_ec2_infra/tasks/resources/resources.yml
+++ b/init_env/aws/roles/manage_ec2_infra/tasks/resources/resources.yml
@@ -103,10 +103,6 @@
     region: "{{ ec2_region }}"
   register: create_key
 
-#- name: Debug create key
-#  ansible.builtin.debug:
-#    var: create_key
-
 - name: Save private key
   ansible.builtin.copy:
     content: "{{ create_key.key.private_key }}"

--- a/init_env/aws/roles/manage_ec2_infra/tasks/teardown.yml
+++ b/init_env/aws/roles/manage_ec2_infra/tasks/teardown.yml
@@ -24,14 +24,11 @@
     ec2_security_group: "{{ ec2_name_prefix }}-insecure_all"
   when: ec2_security_group is undefined
 
-- name: debug ec2_vpc_id
+- name: debug ec2 variables
   debug:
-    var: ec2_vpc_id
-  when: debug_teardown
-
-- name: debug ec2_security_group
-  debug:
-    var: ec2_security_group
+    msg:
+      - "ec2_vpc_id: {{ ec2_vpc_id | default('UNDEFINED') }}"
+      - "ec2_security_group: {{ ec2_security_group | default('UNDEFINED') }}"
   when: debug_teardown
 
 # retrieve instances for VPC 1

--- a/init_env/aws/roles/manage_ec2_infra/tasks/teardown.yml
+++ b/init_env/aws/roles/manage_ec2_infra/tasks/teardown.yml
@@ -7,25 +7,25 @@
   register: vpc_net_facts
 
 - name: debug vpc_net_facts
-  debug:
+  ansible.builtin.debug:
     var: vpc_net_facts
   when: debug_teardown
 
 - name: debugging vpc id for {{ ec2_name_prefix }}
-  debug:
+  ansible.builtin.debug:
     msg: "vpc id:'{{vpc_net_facts.vpcs[0].id}}'"
   when:
     - debug_teardown
     - vpc_net_facts.vpcs|length > 0
 
 - name: use set fact for easier variables
-  set_fact:
+  ansible.builtin.set_fact:
     ec2_vpc_id: "{{vpc_net_facts.vpcs[0].id|default('WORKSHOP_UNDEF')}}"
     ec2_security_group: "{{ ec2_name_prefix }}-insecure_all"
   when: ec2_security_group is undefined
 
 - name: debug ec2 variables
-  debug:
+  ansible.builtin.debug:
     msg:
       - "ec2_vpc_id: {{ ec2_vpc_id | default('UNDEFINED') }}"
       - "ec2_security_group: {{ ec2_security_group | default('UNDEFINED') }}"
@@ -40,7 +40,7 @@
   register: all_workshop_vpc_nodes
 
 - name: debug all_workshop_vpc_nodes
-  debug:
+  ansible.builtin.debug:
     var: all_workshop_vpc_nodes
   when: debug_teardown
 
@@ -58,7 +58,7 @@
     - not aws_cli_destroy_ec2|default(false)|bool
 
 - name: debug result_ec2_destroy
-  debug:
+  ansible.builtin.debug:
     var: result_ec2_destroy
   when: debug_teardown
 
@@ -72,7 +72,7 @@
       register: dangling_eni_info
 
     - name: debug dangling_eni_info
-      debug:
+      ansible.builtin.debug:
         var: dangling_eni_info
       when: debug_teardown
 
@@ -91,7 +91,7 @@
       register: subnet1_eni_info
 
     - name: debug subnet1_eni_info
-      debug:
+      ansible.builtin.debug:
         var: subnet1_eni_info
       when: debug_teardown
 
@@ -159,7 +159,7 @@
   when: item.associations == []
 
 - name: set keys for instance creation dynamically since key was not supplied by user
-  set_fact:
+  ansible.builtin.set_fact:
     ec2_key_name: "{{ ec2_name_prefix }}-key"
 
 - name: delete ssh key pair for workshop {{ ec2_name_prefix }}

--- a/init_env/aws/roles/manage_ec2_instances/tasks/main.yml
+++ b/init_env/aws/roles/manage_ec2_instances/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # Note: we always build AAP. It is in the defaults
 - name: overwrite select ec2_instaces vars if ec2_instances_xtra vars are provided
-  set_fact:
+  ansible.builtin.set_fact:
     ec2_instances: '{{ ec2_instances|combine(ec2_instances_xtra) }}'
   when: (ec2_instances_xtra is defined) and (ec2_instances_xtra is not none)
 

--- a/init_env/aws/teardown.yml
+++ b/init_env/aws/teardown.yml
@@ -12,11 +12,11 @@
     - name: collection final check
       block:
         - name: run AWS check setup if using AWS
-          include_role:
+          ansible.builtin.include_role:
             name: roles/aws_check_setup
       rescue:
         - name: Error with setup
-          fail:
+          ansible.builtin.fail:
             msg: The provisioner has failed during initial check_setup, please scroll up to see exact error.  Open an issue on https://github.com/validatedpatterns/agof/issues
 
 - name: "Get info on the elements built"
@@ -74,6 +74,6 @@
       loop: "{{ built_instances }}"
 
     - name: Remove pattern local files
-      file:
+      ansible.builtin.file:
         dest: "{{ pattern_state_rootdir }}/{{ ec2_name_prefix }}"
         state: absent

--- a/pre_init/jwt_check.yml
+++ b/pre_init/jwt_check.yml
@@ -67,7 +67,7 @@
 - name: Token is not valid any longer
   ansible.builtin.fail:
     msg: >
-      "The {{ local_token_name }} token was generated more than 30 days ago {{ '%Y-%m-%d %H:%M' | strftime(jwt_iat) }}, "
+      "The {{ local_token_name }} token was generated more than {{ local_token_duration_days }} days ago {{ '%Y-%m-%d %H:%M' | strftime(jwt_iat) }}, "
       "you should renew your token. We're continuing, but chances are there might be issues with the token."
   when: (iat_after_duration | int < ansible_date_time['epoch'] | int)
   ignore_errors: true

--- a/pre_init/openshift_vp_preinit.yml
+++ b/pre_init/openshift_vp_preinit.yml
@@ -145,17 +145,12 @@
       ansible.builtin.set_fact:
         admin_password: "{{ admin_pw.resources[0].data.password | b64decode }}"
 
-    - name: Report AAP Endpoint
+    - name: Report AAP connection details
       ansible.builtin.debug:
-        msg: "AAP Endpoint: https://{{ ansible_host }}"
-
-    - name: Report AAP User
-      ansible.builtin.debug:
-        msg: "AAP Admin User: admin"
-
-    - name: Report AAP Admin Password
-      ansible.builtin.debug:
-        msg: "AAP Admin Password: {{ admin_password }}"
+        msg:
+          - "AAP Endpoint: https://{{ ansible_host }}"
+          - "AAP Admin User: admin"
+          - "AAP Admin Password: {{ admin_password }}"
 
     - name: Check on current API status
       ansible.builtin.uri:

--- a/pre_init/templates/agof_overrides.yml.j2
+++ b/pre_init/templates/agof_overrides.yml.j2
@@ -8,8 +8,8 @@ admin_user: admin
 admin_password: "{{ admin_password }}"
 
 aap_username: admin
-aap_password: {{ admin_password }}
-aap_hostname: {{ ansible_host }}
+aap_password: "{{ admin_password }}"
+aap_hostname: "{{ ansible_host }}"
 aap_validate_certs: false
 
 agof_iac_repo: "{{ agof_iac_repo }}"

--- a/pre_init/vars/preinit_vars.yml
+++ b/pre_init/vars/preinit_vars.yml
@@ -10,7 +10,6 @@ ansible_cfg_log_path: '~/lab_builder_ansible.log'
 ansible_cfg_collections_path: '~/.ansible/collections/ansible_collections:/usr/share/ansible/collections/ansible_collections'
 ansible_cfg_patch_collection_dir: '~/.ansible/collections/ansible_collections'
 
-automation_hub_url: '{{ automation_hub_url_vault }}'
 automation_hub_token: '{{ automation_hub_token_vault }}'
 
 init_env_collection_install: true


### PR DESCRIPTION
- **Remove unused automation_hub_url variable**
- **Consolidate AAP debug tasks into a single task**
- **Use local_token_duration_days variable in jwt_check error message**
- **Quote template variables consistently in agof_overrides.yml.j2**
- **Fix broken exception handling in activations_to_enable filter**
- **Remove unused controller_state variable**
- **Rename vague "Debug" task to "Show AAP hostname"**
- **Remove unnecessary block wrapper around pre-config fixups**
- **Consolidate adjacent set_fact tasks in rulebook_activations**
- **Remove commented-out debug task in resources.yml**
- **Consolidate AWS user set_fact tasks in aws_check_setup**
- **Consolidate adjacent debug tasks in teardown.yml**
- **Use fully qualified collection names for builtin modules in init_env**
