### PR TITLE
Switch back to newer utility-container

### DIFF
--- a/scripts/pattern-util.sh
+++ b/scripts/pattern-util.sh
@@ -9,7 +9,7 @@ function version {
 }
 
 if [ -z "$PATTERN_UTILITY_CONTAINER" ]; then
-	PATTERN_UTILITY_CONTAINER="quay.io/validatedpatterns/utility-container:v1.0.2"
+	PATTERN_UTILITY_CONTAINER="quay.io/validatedpatterns/utility-container:v1.0.4"
 fi
 # If PATTERN_DISCONNECTED_HOME is set it will be used to populate both PATTERN_UTILITY_CONTAINER
 # and PATTERN_INSTALL_CHART automatically


### PR DESCRIPTION
Newer versions of the utility-container went back to ansible-2.18 which
should be compatible again:

+podrun:7> podman run -it --security-opt 'label=disable' --rm -v /home/michele:/home/michele:rw --workdir /home/michele '--net=host' --rm quay.io/validatedpatterns/utility-container:v1.0.4 /bin/sh
sh-5.1# ansible --version
ansible [core 2.18.14]
  config file = None
  configured module search path = ['/pattern-home/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.11/site-packages/ansible
  ansible collection location = /pattern-home/.ansible/collections:/usr/share/ansible/collections
  executable location = /usr/local/bin/ansible
  python version = 3.11.13 (main, Jan 16 2026, 00:00:00) [GCC 11.5.0 20240719 (Red Hat 11.5.0-11)] (/usr/bin/python3)
  jinja version = 3.1.6
  libyaml = True
