### PR TITLE
Fix installer download process and get AAP 2.6 by default

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -13,7 +13,14 @@
 * Add mechanism to disable eda_rulebook_activations prior to configuring them to prevent crash of aap configuration
   playbook while trying to manage running rulebook activations
 
-## Update to v2 (April 22026)
+## Update to v2 (April 2026)
 
 * Note that AGOFv2 Also support AAP 2.6
 * Add a parameter to the openshift pre-init playbook to allow skipping the local vault load.
+
+## Update to v2 (May 2026)
+
+* Default AGOFv2 to AAP 2.6
+* Improve numerous error messages and provide a pre-check target.
+* Fix an issue where change to infra.aap_utilties.aap_setup_download could not find an installer to download, causing
+installation to fail for containerized installer.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The thinking behind this effort is documented in the [Ansible Pattern Theory](ht
 
 ## 2. <a name='HowtoUseIt'></a>How to Use It
 
-The default installation will provide an AAP 2.5 installation deployed via the Containerized Installer, with the following services available on the AAP node (where `aapnode.fqdn` is the fully qualified domain name of your AAP host):
+The default installation will provide an AAP 2.6 installation deployed via the Containerized Installer, with the following services available on the AAP node (where `aapnode.fqdn` is the fully qualified domain name of your AAP host):
 
 | URL Pattern | Service |
 |-------------|---------|
@@ -81,7 +81,7 @@ agof_iac_repo: "https://github.com/validatedpatterns-demos/agof_minimal_config.g
 ./pattern.sh make install
 ```
 
-This builds the default pattern configuration on AWS, which (by default) includes a containerized install of AAP 2.5 on a single AWS VM. Various add-ons can be included by adding variables to the `~/agof_vault.yml` file as described below - these options will all be honored as the pattern installs itself.
+This builds the default pattern configuration on AWS, which (by default) includes a containerized install of AAP 2.6 on a single AWS VM. Various add-ons can be included by adding variables to the `~/agof_vault.yml` file as described below - these options will all be honored as the pattern installs itself.
 
 ### 2.2. <a name='Uninstallation'></a>Uninstallation
 

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ The teardown play will terminate all VMs associated with a VPC and subnet, and r
 | ------------------------- | ------------------------------------ | -------- | ------------------ | ------- |
 | containerized_installer_user | Unprivileged user to create to run AAP | true | `aap` | |
 | containerized_installer_user_home | Directory to install containerized AAP into | true | `/home/{{ containerized_installer_user }}` | |
-| containerized_installer_version | Minor version of AAP to install | false | "2.5" | |
+| containerized_installer_version | Minor version of AAP to install | false | "2.6" | |
 | automation_hub | Boolean to indicate whether to install automation_hub | true | true | |
 | postgresql_admin_username | Name of postgres admin for services | true | `postgres` | |
 | postgresql_admin_password | Password for the postgres user for services | true | `{{ db_password }}` | |

--- a/containerized_install/roles/installer/defaults/main.yml
+++ b/containerized_install/roles/installer/defaults/main.yml
@@ -7,7 +7,7 @@ containerized_installer_user_home: '/home/{{ containerized_installer_user }}'
 
 containerized_installer_cleanup: true
 
-containerized_installer_version: "2.5"
+containerized_installer_version: "2.6"
 containerized_installer_dest_dir: "{{ containerized_installer_user_home }}"
 
 controller_fqdn: "{{ ansible_facts.fqdn }}"

--- a/containerized_install/roles/installer/tasks/main.yml
+++ b/containerized_install/roles/installer/tasks/main.yml
@@ -20,9 +20,9 @@
       vars:
         aap_setup_down_offline_token: "{{ offline_token }}"
         aap_setup_down_version: "{{ containerized_installer_version }}"
-        aap_setup_down_type: containerized-setup
-        aap_setup_down_dest_dir: "{{ containerized_installer_user_home }}"
+        aap_setup_down_type: setup
         aap_setup_containerized: true
+        aap_setup_down_dest_dir: "{{ containerized_installer_user_home }}"
 
     - name: Extract containerized installer
       ansible.builtin.unarchive:


### PR DESCRIPTION
* Update default AAP version to download/install to 2.6
* Fix an issue in the installer download phase that would prevent the setup tarball from downloading, which would cause install to fail